### PR TITLE
WIP: suport colorscale, custom labels and scattergl

### DIFF
--- a/python/python.ml
+++ b/python/python.ml
@@ -28,6 +28,7 @@ let of_graph Graph.{type_; data} =
     match type_ with
     | "scatter" -> "Scatter"
     | "scatter3d" -> "Scatter3d"
+    | "scattergl" -> "Scattergl"
     | "bar" -> "Bar"
     | "pie" -> "Pie"
     | _ -> assert false

--- a/python/python.ml
+++ b/python/python.ml
@@ -23,7 +23,7 @@ type _ t = Py.Object.t
 
 type figure
 
-let of_graph Graph.{type_; data} =
+let of_graph ?(z = [||]) ?text Graph.{type_; data} =
   let c =
     match type_ with
     | "scatter" -> "Scatter"
@@ -33,8 +33,25 @@ let of_graph Graph.{type_; data} =
     | "pie" -> "Pie"
     | _ -> assert false
   in
+  let base_attributes = of_attributes (data :> Attribute.t list) in
+  let marker_attributes = Some [
+    "colorscale", Py.String.of_string "Viridis";
+    "color", Py.List.of_array_map Py.Float.of_float z;
+    "size", Py.Int.of_int 1;
+  ]
+  in
+  let py_attributes =
+    List.concat [
+      base_attributes;
+      (Option.fold ~none:[] ~some:(fun l ->
+        [ "marker", Py.Dict.of_bindings_string l ]) marker_attributes);
+      (Option.fold ~none:[] ~some:(fun a ->
+        [ "text", Py.List.of_array_map Py.String.of_string a ]
+      ) text)
+    ]
+  in
   Py.Module.get_function_with_keywords go c [||]
-    (of_attributes (data :> Attribute.t list))
+    py_attributes
 
 let of_layout layout =
   let layout = (layout : Layout.t :> Attribute.t list) in
@@ -43,8 +60,8 @@ let of_layout layout =
     of_value
     layout
 
-let of_figure fig : figure t =
-  let data = Py.List.of_list_map of_graph fig.Figure.graphs in
+let of_figure ?z ?text fig : figure t =
+  let data = Py.List.of_list_map (of_graph ?z ?text) fig.Figure.graphs in
   let layout = of_layout fig.layout in
   Py.Module.get_function_with_keywords go "Figure" [||]
     ["data", data;

--- a/python/python.mli
+++ b/python/python.mli
@@ -2,7 +2,7 @@ type _ t = private Py.Object.t
 
 type figure
 
-val of_figure : Plotly.Figure.t -> figure t
+val of_figure : ?z:float array -> ?text:string array -> Plotly.Figure.t -> figure t
 
 val show : ?renderer:string -> figure t -> unit
 val write_image : figure t -> string -> unit

--- a/src/plotly.ml
+++ b/src/plotly.ml
@@ -51,6 +51,7 @@ module Graph = struct
 
   let scatter data_list = { type_ = "scatter"; data= List.flatten data_list }
   let scatter3d data_list = { type_ = "scatter3d"; data= List.flatten data_list }
+  let scattergl data_list = { type_ = "scattergl"; data= List.flatten data_list }
   let bar data_list = { type_ = "bar"; data= List.flatten data_list }
   let pie data_list = { type_ = "pie"; data= List.flatten data_list }
   let histogram data_list = { type_ = "histogram"; data= List.flatten data_list }

--- a/src/plotly.mli
+++ b/src/plotly.mli
@@ -77,6 +77,7 @@ module Graph : sig
 
   val scatter : Data.t list -> t
   val scatter3d : Data.t list -> t
+  val scattergl : Data.t list -> t
   val bar : Data.t list -> t
   val pie : Data.t list -> t
   val histogram : Data.t list -> t


### PR DESCRIPTION
Hey, I've started using plotly and I'm very happy to have bindings for it!

I wanted to add a Viridis colorscale and label all my markers. Unfortunately this doesn't really fit in well with the current API (and Plotly's API does not always make things easy) and I wanted to start a discussion on how to integrate these two things.

First, "colorscale" is an attribute in the "marker" attribute and there are several ways to use it, including passing all the colors to use one-by-one but the most common case is probably to pass all your data and habe plotly create the colormap.

Second, "text" is a direct attribute and it's simply the strings in the same order as the points to label.

I think it's possible to add a `?text` argument as I've done here. I don't think the current code for marker and color scale is fine however and I'd like your input.

It's possible to extend the `Base.Type.t` and convert using it but that's quite a bit of work and there are probably more cases (here, I already needed an array of elements that are either a string, an integer or a float array). What do you think about allowing the user to directly pass custom attributes directly as lists of python values? In the linked code, `marker_attributes` would be a parameter instead of being defined in `plotly-ocaml`.

PS: I think the string `"marker"` shouldn't be constant but that doesn't change the crux of the topic.