### PR TITLE
Allow setting marker color

### DIFF
--- a/jsoo/jsoo.ml
+++ b/jsoo/jsoo.ml
@@ -12,6 +12,18 @@ let rec conv_value v =
   | Value (Array ty, vs) ->
       let vs = Array.map (fun v -> conv_value (Value (ty, v))) vs in
       Js.Unsafe.inject @@ Js.array vs
+  | Value (Object, obj) -> of_json_value (obj : Ezjsonm.value)
+
+and of_json_value (j : Ezjsonm.value) : _ Js.t =
+  match (j : Ezjsonm.value) with
+  | `String s -> Js.Unsafe.inject @@ Js.string s
+  | `Float f -> Js.Unsafe.inject f
+  | `Bool b -> Js.Unsafe.inject b
+  | `Null -> Js.Unsafe.inject Js.null
+  | `A vs -> Js.Unsafe.inject @@ Js.array (Array.of_list (List.map of_json_value vs))
+  | `O kvs ->
+      Js.Unsafe.obj @@ Array.of_list @@
+      List.map (fun (k, v) -> (k, of_json_value v)) kvs
 
 let obj_of_attributes (xs : Attribute.t list) : _ Js.t =
   Js.Unsafe.obj @@

--- a/python/python.ml
+++ b/python/python.ml
@@ -7,6 +7,19 @@ let rec of_value v =
   | Value (String, s) -> Py.String.of_string s
   | Value (Array ty, vs) ->
       Py.List.of_array @@ Array.map (fun v -> of_value (Value (ty, v))) vs
+  | Value (Object, obj) -> of_json_value (obj : Ezjsonm.value)
+
+and of_json_value (j : Ezjsonm.value) : Py.Object.t =
+  match (j : Ezjsonm.value) with
+  | `String s -> Py.String.of_string s
+  | `Float f -> Py.Float.of_float f
+  | `Bool b -> Py.Bool.of_bool b
+  | `Null -> Py.none
+  | `A vs -> Py.List.of_list_map of_json_value vs
+  | `O kvs ->
+      let py_dict = Py.Dict.create () in
+      List.iter (fun (k, v) -> Py.Dict.set_item_string py_dict k (of_json_value v)) kvs;
+      py_dict
 
 let of_attribute (s, v : Attribute.t) = (s, of_value v)
 

--- a/src/base.ml
+++ b/src/base.ml
@@ -96,7 +96,7 @@ module Marker = struct
   let color c = string "color" c
   let colors cs = array "color" Type.String cs
 
-  let marker ats = ats
+  let marker ats = List.concat ats
 
   let to_json = Attributes.to_json
   let of_json = Attributes.of_json

--- a/src/base.mli
+++ b/src/base.mli
@@ -39,11 +39,11 @@ end
 module Marker : sig
   type t = private Attribute.t list
 
-  val color : string -> t
+  val color : string -> Attribute.t list
 
-  val colors : string array -> t
+  val colors : string array -> Attribute.t list
 
-  val marker : Attribute.t list -> t
+  val marker : Attribute.t list list -> t
 
   val to_json : t -> Ezjsonm.value
   val of_json : Ezjsonm.value -> t option

--- a/src/base.mli
+++ b/src/base.mli
@@ -3,6 +3,7 @@ module Type : sig
     | Float : float t
     | String : string t
     | Array : 'a t -> 'a array t
+    | Object : Ezjsonm.value t
 
   type type_ = Type : _ t -> type_
 end
@@ -14,6 +15,7 @@ module Value : sig
   val float : float -> float t
   val string : string -> string t
   val array : 'a Type.t -> 'a array -> 'a array t
+  val object_ : Ezjsonm.value -> Ezjsonm.value t
 
   val to_json : value -> Ezjsonm.value
   val of_json : Ezjsonm.value -> value option
@@ -29,6 +31,19 @@ module Attributes : sig
   val float : string -> float -> Attribute.t list
   val string : string -> string -> Attribute.t list
   val array : string -> 'a Type.t -> 'a array -> Attribute.t list
+
+  val to_json : t -> Ezjsonm.value
+  val of_json : Ezjsonm.value -> t option
+end
+
+module Marker : sig
+  type t = private Attribute.t list
+
+  val color : string -> t
+
+  val colors : string array -> t
+
+  val marker : Attribute.t list -> t
 
   val to_json : t -> Ezjsonm.value
   val of_json : Ezjsonm.value -> t option

--- a/src/plotly.ml
+++ b/src/plotly.ml
@@ -26,6 +26,10 @@ module Data = struct
     let zs = Array.map (fun (_,_,z) -> z) xyzs in
     x xs @ y ys @ z zs
 
+  let marker (marker_attrs : Marker.t) : t =
+    let marker_obj = Attributes.to_json (marker_attrs :> Attribute.t list) in
+    ["marker", Value.Value (Value.object_ marker_obj)]
+
   let data ds = ds
 
   let to_json = Attributes.to_json

--- a/src/plotly.ml
+++ b/src/plotly.ml
@@ -26,8 +26,9 @@ module Data = struct
     let zs = Array.map (fun (_,_,z) -> z) xyzs in
     x xs @ y ys @ z zs
 
-  let marker (marker_attrs : Marker.t) : t =
-    let marker_obj = Attributes.to_json (marker_attrs :> Attribute.t list) in
+  let marker (marker_attrs : Attribute.t list list) : t =
+    let combined = Marker.marker marker_attrs in
+    let marker_obj = Attributes.to_json (combined :> Attribute.t list) in
     ["marker", Value.Value (Value.object_ marker_obj)]
 
   let data ds = ds

--- a/src/plotly.mli
+++ b/src/plotly.mli
@@ -3,6 +3,7 @@ module Type : sig
     | Float : float t
     | String : string t
     | Array : 'a t -> 'a array t
+    | Object : Ezjsonm.value t
 
   type type_ = Type : _ t -> type_
 end
@@ -13,6 +14,7 @@ module Value : sig
   val float : float -> float t
   val string : string -> string t
   val array : 'a Type.t -> 'a array -> 'a array t
+  val object_ : Ezjsonm.value -> Ezjsonm.value t
 
   val to_json : value -> Ezjsonm.value
   val of_json : Ezjsonm.value -> value option
@@ -28,6 +30,30 @@ module Attributes : sig
   val float : string -> float -> Attribute.t list
   val string : string -> string -> Attribute.t list
   val array : string -> 'a Type.t -> 'a array -> Attribute.t list
+
+  val to_json : t -> Ezjsonm.value
+  val of_json : Ezjsonm.value -> t option
+end
+
+module Marker : sig
+  type t = private Attribute.t list
+
+  (** 
+    Set a single color for all data points. 
+
+    The color may be specified by its color name (e.g., ["LightBlue"]), hex code (e.g., ["#ADD8E6"]), or RGB(A) string (e.g., ["rgba(173, 216, 230, 1)"]). 
+    The latter allows for specifying transparency.
+  *)
+  val color : string -> t
+
+  (** 
+    Set the colors for each of the data points, such that each color corresponds to a data point. 
+
+    The colors may be specified by their color name (e.g., ["LightBlue"]), hex codes (e.g., ["#ADD8E6"]), or RGB(A) strings (e.g., ["rgba(173, 216, 230, 1)"]). 
+    The latter allows for specifying transparency.
+  *)
+  val colors : string array -> t
+  val marker : Attribute.t list -> t
 
   val to_json : t -> Ezjsonm.value
   val of_json : Ezjsonm.value -> t option
@@ -51,6 +77,9 @@ module Data : sig
 
   (* The argument is splitted to build attributes [x], [y], and [z] *)
   val xyz : (float * float * float) array -> t
+
+  (* Attach marker configuration to the trace *)
+  val marker : Marker.t -> t
 
   (* Build custom data attributes *)
   val data : Attribute.t list -> t

--- a/src/plotly.mli
+++ b/src/plotly.mli
@@ -44,7 +44,7 @@ module Marker : sig
     The color may be specified by its color name (e.g., ["LightBlue"]), hex code (e.g., ["#ADD8E6"]), or RGB(A) string (e.g., ["rgba(173, 216, 230, 1)"]). 
     The latter allows for specifying transparency.
   *)
-  val color : string -> t
+  val color : string -> Attribute.t list
 
   (** 
     Set the colors for each of the data points, such that each color corresponds to a data point. 
@@ -52,8 +52,8 @@ module Marker : sig
     The colors may be specified by their color name (e.g., ["LightBlue"]), hex codes (e.g., ["#ADD8E6"]), or RGB(A) strings (e.g., ["rgba(173, 216, 230, 1)"]). 
     The latter allows for specifying transparency.
   *)
-  val colors : string array -> t
-  val marker : Attribute.t list -> t
+  val colors : string array -> Attribute.t list
+  val marker : Attribute.t list list -> t
 
   val to_json : t -> Ezjsonm.value
   val of_json : Ezjsonm.value -> t option
@@ -78,8 +78,7 @@ module Data : sig
   (* The argument is splitted to build attributes [x], [y], and [z] *)
   val xyz : (float * float * float) array -> t
 
-  (* Attach marker configuration to the trace *)
-  val marker : Marker.t -> t
+  val marker : Attribute.t list list -> t
 
   (* Build custom data attributes *)
   val data : Attribute.t list -> t


### PR DESCRIPTION
This change enables setting the marker color of traces, inspired mostly by the Plotly Python API. 

It makes traces accept a list of marker options, such that more marker attributes can be easily added later (border, size, etc.). 